### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ numpy
 httpretty
 mock
 coveralls
-flask-consulate
+flask-consulate==0.1.2


### PR DESCRIPTION
Flask consulate 0.1.2 is needed for specifying consul port number.